### PR TITLE
Changed ComputeSPMV_ref calculation

### DIFF
--- a/src/ComputeSPMV_ref.cpp
+++ b/src/ComputeSPMV_ref.cpp
@@ -21,6 +21,9 @@
 #include "ComputeSPMV_ref.hpp"
 
 #ifndef HPCG_NOMPI
+#include <mpi.h>
+#include "Geometry.hpp"
+#include <cstdlib>
 #include "ExchangeHalo.hpp"
 #endif
 
@@ -49,9 +52,67 @@ int ComputeSPMV_ref( const SparseMatrix & A, Vector & x, Vector & y) {
   assert(x.localLength>=A.localNumberOfColumns); // Test vector lengths
   assert(y.localLength>=A.localNumberOfRows);
 
+  double * const xv_halo = x.values; // Stores the xvalues for the halo
 #ifndef HPCG_NOMPI
-    ExchangeHalo(A,x);
-#endif
+    //ExchangeHalo(A,x);
+
+  local_int_t localNumberOfRows = A.localNumberOfRows;
+  int num_neighbors = A.numberOfSendNeighbors;
+  local_int_t * receiveLength = A.receiveLength;
+  local_int_t * sendLength = A.sendLength;
+  int * neighbors = A.neighbors;
+  double * sendBuffer = A.sendBuffer;
+  local_int_t totalToBeSent = A.totalToBeSent;
+  local_int_t * elementsToSend = A.elementsToSend;
+
+  int size, rank; // Number of MPI processes, My process ID
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  //
+  //  first post receives, these are immediate receives
+  //  Do not wait for result to come, will do that at the
+  //  wait call below.
+  //
+
+  int MPI_MY_TAG = 99;
+
+  MPI_Request * request = new MPI_Request[num_neighbors];
+
+  //
+  // Externals are at end of locals
+  //
+  double * x_external = (double *) xv_halo + localNumberOfRows;
+
+  // Post receives first
+  // TODO: Thread this loop
+  for (int i = 0; i < num_neighbors; i++) {
+    local_int_t n_recv = receiveLength[i];
+    MPI_Irecv(x_external, n_recv, MPI_DOUBLE, neighbors[i], MPI_MY_TAG, MPI_COMM_WORLD, request+i);
+    x_external += n_recv;
+  }
+
+
+  //
+  // Fill up send buffer
+  //
+
+  // TODO: Thread this loop
+  for (local_int_t i=0; i<totalToBeSent; i++) sendBuffer[i] = xv_halo[elementsToSend[i]];
+
+  //
+  // Send to each neighbor
+  //
+
+  // TODO: Thread this loop
+  for (int i = 0; i < num_neighbors; i++) {
+    local_int_t n_send = sendLength[i];
+    MPI_Send(sendBuffer, n_send, MPI_DOUBLE, neighbors[i], MPI_MY_TAG, MPI_COMM_WORLD);
+    sendBuffer += n_send;
+  }
+
+#endif //#ifndef HPCG_NOMPI
+
   const double * const xv = x.values;
   double * const yv = y.values;
   const local_int_t nrow = A.localNumberOfRows;
@@ -63,10 +124,40 @@ int ComputeSPMV_ref( const SparseMatrix & A, Vector & x, Vector & y) {
     const double * const cur_vals = A.matrixValues[i];
     const local_int_t * const cur_inds = A.mtxIndL[i];
     const int cur_nnz = A.nonzerosInRow[i];
+    for (int j=0; j< cur_nnz; j++)	{
+			if(cur_inds[j] < nrow)	{
+				sum += cur_vals[j]*xv[cur_inds[j]];
+				yv[i] = sum;
+			}
+		}
+	}
 
-    for (int j=0; j< cur_nnz; j++)
-      sum += cur_vals[j]*xv[cur_inds[j]];
-    yv[i] = sum;
+#ifndef HPCG_NOMPI
+//
+// Complete the reads issued in ExchangeHalo.cpp
+//
+ MPI_Status status;
+  // TODO: Thread this loop
+  for (int i = 0; i < num_neighbors; i++) {
+    if ( MPI_Wait(request+i, &status) ) {
+      std::exit(-1); // TODO: have better error exit
+    }
   }
+#endif
+
+  for (local_int_t i=0; i< nrow; i++)  {
+    double sum = 0.0;
+    const double * const cur_vals = A.matrixValues[i];
+    const local_int_t * const cur_inds = A.mtxIndL[i];
+    const int cur_nnz = A.nonzerosInRow[i];
+    for (int j=0; j< cur_nnz; j++)	{
+			if(cur_inds[j] >= nrow)	{
+				sum += cur_vals[j]*xv[cur_inds[j]];
+				yv[i] = sum;
+			}
+		}
+	}
+
+
   return(0);
 }


### PR DESCRIPTION
Moved ExchangeHalo code into the ComputeSPMV_ref code.
Code now should calculate local and external values separately.
The receiving of halo values now happens while multiplications between local values are calculated.
Do not know if it compiles as a whole with HPCG.
