### PR TITLE
[Proposal] Use std::unordered_map for A.globalToLocalMap instead of std::map

### DIFF
--- a/src/SparseMatrix.hpp
+++ b/src/SparseMatrix.hpp
@@ -21,12 +21,20 @@
 #ifndef SPARSEMATRIX_HPP
 #define SPARSEMATRIX_HPP
 
-#include <unordered_map>
 #include <vector>
 #include <cassert>
 #include "Geometry.hpp"
 #include "Vector.hpp"
 #include "MGData.hpp"
+#if __cplusplus <= 201103L
+// for C++03
+#include <map>
+typedef std::map< global_int_t, local_int_t > GlobalToLocalMap;
+#else
+// for C++11 or greater
+#include <unordered_map>
+using GlobalToLocalMap = std::unorderd_map< global_int_t, local_int_t >;
+#endif
 
 struct SparseMatrix_STRUCT {
   char  * title; //!< name of the sparse matrix
@@ -41,7 +49,7 @@ struct SparseMatrix_STRUCT {
   local_int_t ** mtxIndL; //!< matrix indices as local values
   double ** matrixValues; //!< values of matrix entries
   double ** matrixDiagonal; //!< values of matrix diagonal entries
-  std::unordered_map< global_int_t, local_int_t > globalToLocalMap; //!< global-to-local mapping
+  GlobalToLocalMap globalToLocalMap; //!< global-to-local mapping
   std::vector< global_int_t > localToGlobalMap; //!< local-to-global mapping
   mutable bool isDotProductOptimized;
   mutable bool isSpmvOptimized;

--- a/src/SparseMatrix.hpp
+++ b/src/SparseMatrix.hpp
@@ -21,7 +21,7 @@
 #ifndef SPARSEMATRIX_HPP
 #define SPARSEMATRIX_HPP
 
-#include <map>
+#include <unordered_map>
 #include <vector>
 #include <cassert>
 #include "Geometry.hpp"
@@ -41,7 +41,7 @@ struct SparseMatrix_STRUCT {
   local_int_t ** mtxIndL; //!< matrix indices as local values
   double ** matrixValues; //!< values of matrix entries
   double ** matrixDiagonal; //!< values of matrix diagonal entries
-  std::map< global_int_t, local_int_t > globalToLocalMap; //!< global-to-local mapping
+  std::unordered_map< global_int_t, local_int_t > globalToLocalMap; //!< global-to-local mapping
   std::vector< global_int_t > localToGlobalMap; //!< local-to-global mapping
   mutable bool isDotProductOptimized;
   mutable bool isSpmvOptimized;


### PR DESCRIPTION
This is a proposal pull-request.

Since std::map is implemented as a binary tree, its storing/loading a value takes [O(log N)](http://www.cplusplus.com/reference/map/map/operator[]/#complexity).

But we don't need a binary tree for SparseMatrix's globalToLocalMap but just need a key-value table.
Now we can use std::unordered_map (hash map) in C++11 for such purpose.

This change reduces "Setup Time" by half (9.32255[sec] to 4.75407[sec]) with (nx,ny,nz)=(104,104,104) in my system (Core i7-4820K, DDR3-1600).

Many users/benchmarkers should benefit because [GCC 6.0 uses C++14 as its default version](https://gcc.gnu.org/gcc-6/changes.html) and many other compilers (e.g. clang, VC++, icc) also supported C++11 now.

I suggest for you using std::unordered_map for A.globalToLocalMap instead of std::map to reduce the default setup phase overhead.
