### PR TITLE
Relaxed the convergence and tolerance failure checks to allow differences beyond first six meaningful digits

### DIFF
--- a/src/CG.cpp
+++ b/src/CG.cpp
@@ -96,8 +96,8 @@ int CG(const SparseMatrix & A, CGData & data, const Vector & b, Vector & x,
   normr0 = normr;
 
   // Start iterations
-
-  for (int k=1; k<=max_iter && normr/normr0 > tolerance; k++ ) {
+  // Convergence check has a "safety" factor of 1.0e-6
+  for (int k=1; k<=max_iter && normr/normr0 > tolerance * (1.0 + 1.0e-6); k++ ) {
     TICK();
     if (doPreconditioning)
       ComputeMG(A, r, z); // Apply preconditioner

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -223,6 +223,7 @@ int main(int argc, char * argv[]) {
     totalNiters_ref += niters;
   }
   if (rank == 0 && err_count) HPCG_fout << err_count << " error(s) in call(s) to reference CG." << endl;
+  double normr_ref = normr;
   double refTolerance = normr / normr0;
 
   // Call user-tunable set up function.
@@ -283,7 +284,7 @@ int main(int argc, char * argv[]) {
     double last_cummulative_time = opt_times[0];
     ierr = CG( A, data, b, x, optMaxIters, refTolerance, niters, normr, normr0, &opt_times[0], true);
     if (ierr) ++err_count; // count the number of errors in CG
-    if (normr / normr0 > refTolerance) ++tolerance_failures; // the number of failures to reduce residual
+    if (1e6 * (normr - normr_ref > normr0)) ++tolerance_failures; // the number of failures to reduce residual
 
     // pick the largest number of iterations to guarantee convergence
     if (niters > optNiters) optNiters = niters;


### PR DESCRIPTION
Summary:

For optimized CG implementations, it can happen that the check for the convergence `normr/normr0 > tolerance` (where `normr` is the current residual norm, `normr0` is the initial residual norm and `tolerance` is the final residual ratio for the reference CG) will fail because several of the last few digits of `norm` are larger than those of `normr0 * tolerance`.

Example:
...
Iteration = 49 0.00162483940034649 0   Scaled Residual = 0.00194460573779805 tolerance = 0.00162483940034649
Iteration = 50 0.00162483940034649 0   Scaled Residual = 0.001624839400346**74** tolerance = 0.001624839400346**49** 
// so it doesn't stop at iteration #50 while it naturally should have
Iteration = 51 0.00162483940034649 0   Scaled Residual = 0.00156761297375884 tolerance = 0.00162483940034649

The cause of this is very likely just the floating point accumulation errors.

Then, convergence will be not detected and redundant iterations will be done (hence the performance will drop).

Proposed change: Introduce some more robustness when checking for convergence or `tolerance_failures`. Strictly speaking, the new check in CG.cpp allows divergence of `tolerance * 1.0e-6` which is larger than six meaningful digits, but close to it hence the PR's title.

Tested locally. 

NOTE: A better check in CG.cpp would look like the one in main.cpp
`1e6 * (normr - normr_ref > normr0)`
but this would require changing the API (to pass normr_ref additionally). Hence this approach has been declined for CG.cpp.