### PR TITLE
Relaxed the convergence and tolerance failure checks to allow differences beyond first six meaningful digits

### DIFF
--- a/src/CG.cpp
+++ b/src/CG.cpp
@@ -96,8 +96,8 @@ int CG(const SparseMatrix & A, CGData & data, const Vector & b, Vector & x,
   normr0 = normr;
 
   // Start iterations
-
-  for (int k=1; k<=max_iter && normr/normr0 > tolerance; k++ ) {
+  // Convergence check accepts an error of no more than 6 significant digits of tolerance
+  for (int k=1; k<=max_iter && normr/normr0 > tolerance * (1.0 + 1.0e-6); k++ ) {
     TICK();
     if (doPreconditioning)
       ComputeMG(A, r, z); // Apply preconditioner

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -283,7 +283,8 @@ int main(int argc, char * argv[]) {
     double last_cummulative_time = opt_times[0];
     ierr = CG( A, data, b, x, optMaxIters, refTolerance, niters, normr, normr0, &opt_times[0], true);
     if (ierr) ++err_count; // count the number of errors in CG
-    if (normr / normr0 > refTolerance) ++tolerance_failures; // the number of failures to reduce residual
+    // Convergence check accepts an error of no more than 6 significant digits of relTolerance
+    if (normr / normr0 > refTolerance * (1.0 + 1.0e-6)) ++tolerance_failures; // the number of failures to reduce residual
 
     // pick the largest number of iterations to guarantee convergence
     if (niters > optNiters) optNiters = niters;


### PR DESCRIPTION
Fixes a source code typo from https://github.com/hpcg-benchmark/hpcg/pull/67 which was merged and then reverted https://github.com/hpcg-benchmark/hpcg/pull/70
