### PR TITLE
Fix typos in INSTALL file

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -90,10 +90,10 @@ are::
 
 HPCG supports in-source and out-of-source builds. In the case of the
 former, the object files and the binary reside in the same directory
-structure as the source files. There is no need for a seperate
+structure as the source files. There is no need for a separate
 configuration step and the reader may skip the the Build section.
 
-In the latter case, a seperate directory is created to hold the object
+In the latter case, a separate directory is created to hold the object
 and binary executable files.  For example, create a custom directory,
 ``build`` in this example, for the results of compilation and linking::
 


### PR DESCRIPTION
Fix two occurrences of "seperate" -> "separate"